### PR TITLE
_BV Macro check

### DIFF
--- a/Adafruit_SSD1305.cpp
+++ b/Adafruit_SSD1305.cpp
@@ -38,6 +38,11 @@ SPISettings oledspi = SPISettings(4000000, MSBFIRST, SPI_MODE0);
 #define ADAFRUIT_SSD1305_SPI SPI_CLOCK_DIV2
 #endif
 
+// The _BV macro is defined by in the avr libraries
+// This allows the SSD1305 to work with other architectures, like the M0
+#ifndef _BV
+#define _BV(bit) (1 << (bit))
+#endif
 
 // a 5x7 font table
 extern const uint8_t PROGMEM font[];

--- a/Adafruit_SSD1305.cpp
+++ b/Adafruit_SSD1305.cpp
@@ -353,7 +353,8 @@ void Adafruit_SSD1305::display(void) {
 
     if (cs == -1) {
       // save I2C bitrate
-#ifndef __SAM3X8E__
+//#ifndef __SAM3X8E__
+#ifdef __AVR__
       uint8_t twbrbackup = TWBR;
       TWBR = 12; // upgrade to 400KHz!
 #endif
@@ -372,7 +373,8 @@ void Adafruit_SSD1305::display(void) {
 	Wire.endTransmission();
       }
 
-#ifndef __SAM3X8E__
+//#ifndef __SAM3X8E__
+#ifdef __AVR__
       TWBR = twbrbackup;
 #endif
     } else {


### PR DESCRIPTION
_BV is defined in the avr architecture libraries, and will not be
present if using non-avr microprocessors.

Check if _BV is defined. 
If not, define as #define _BV(bit) (1 << (bit))
