### PR TITLE
#20 Updated hardware SPI initialization and message

### DIFF
--- a/examples/ssd1305test/ssd1305test.ino
+++ b/examples/ssd1305test/ssd1305test.ino
@@ -34,8 +34,8 @@ All text above, and the splash screen below must be included in any redistributi
 
 // software SPI
 //Adafruit_SSD1305 display(128, 64, OLED_MOSI, OLED_CLK, OLED_DC, OLED_RESET, OLED_CS);
-// hardware SPI
-Adafruit_SSD1305 display(128, 64, &SPI, OLED_DC, OLED_RESET, OLED_CS);
+// hardware SPI - use 7Mhz (7000000UL) or lower because the screen is rated for 4MHz, or it will remain blank!
+Adafruit_SSD1305 display(128, 64, &SPI, OLED_DC, OLED_RESET, OLED_CS, 7000000UL);
 
 // I2C
 //Adafruit_SSD1305 display(128, 64, &Wire, OLED_RESET);


### PR DESCRIPTION
The ssd1305test example calls a hardware SPI c-tor without specifying the clock rate, which is the last (optional) argument for that c-tor. This uses an 8 Mhz clock rate by default, which is not supported by the screen. The screen manufacturer recommends 4Mhz, but the screen practically works at 7 Mhz.

See https://forums.adafruit.com/viewtopic.php?f=47&t=168521&p=825031&hilit=SSD1305+hardware+spi#p825007

I recommend specifying that additional parameter as 7 Mhz in sample code and updating the comment to state 7 Mhz or lower is required.