### PR TITLE
added sleep and wake methods for the ssd1305. 

### DIFF
--- a/Adafruit_SSD1305.cpp
+++ b/Adafruit_SSD1305.cpp
@@ -338,19 +338,13 @@ void Adafruit_SSD1305::display(void) {
   window_y2 = -1;
 }
 
-
 /*!
-    @brief  Put the display driver into a low power mode instead of just turning off all pixels
+    @brief  Put the display driver into a low power mode instead of just turning
+   off all pixels
 */
-void Adafruit_SSD1305::sleep(void) {
-oled_command(SSD1305_DISPLAYOFF); 
-
-}
+void Adafruit_SSD1305::sleep(void) { oled_command(SSD1305_DISPLAYOFF); }
 
 /*!
     @brief  Wake the display driver from the low power mode
 */
-void Adafruit_SSD1305::wake(void) {
-oled_command(SSD1305_DISPLAYON); 
-
-}
+void Adafruit_SSD1305::wake(void) { oled_command(SSD1305_DISPLAYON); }

--- a/Adafruit_SSD1305.cpp
+++ b/Adafruit_SSD1305.cpp
@@ -337,3 +337,20 @@ void Adafruit_SSD1305::display(void) {
   window_x2 = -1;
   window_y2 = -1;
 }
+
+
+/*!
+    @brief  Put the display driver into a low power mode instead of just turning off all pixels
+*/
+void Adafruit_SSD1305::sleep(void) {
+oled_command(SSD1305_DISPLAYOFF); 
+
+}
+
+/*!
+    @brief  Wake the display driver from the low power mode
+*/
+void Adafruit_SSD1305::wake(void) {
+oled_command(SSD1305_DISPLAYON); 
+
+}

--- a/Adafruit_SSD1305.h
+++ b/Adafruit_SSD1305.h
@@ -77,3 +77,4 @@ private:
   int8_t page_offset = 0;
   int8_t column_offset = 0;
 };
+

--- a/Adafruit_SSD1305.h
+++ b/Adafruit_SSD1305.h
@@ -77,4 +77,3 @@ private:
   int8_t page_offset = 0;
   int8_t column_offset = 0;
 };
-

--- a/Adafruit_SSD1305.h
+++ b/Adafruit_SSD1305.h
@@ -70,6 +70,8 @@ public:
 
   bool begin(uint8_t i2caddr = SSD1305_I2C_ADDRESS, bool reset = true);
   void display();
+  void sleep();
+  void wake();
 
 private:
   int8_t page_offset = 0;


### PR DESCRIPTION
 tested vs ada ssd1305 oled and with ada feather m0 dev board.  reduced sleep current to ~30 uA instead
of 2-3 mA.  Very helpful for battery powered devices.

use:

call sleep() to put the device into low power mode.  According to the datasheet, "When the display is OFF, those circuits will be turned OFF and the segment and common output are in high
impedance state"

call wake() to wake back up.  Neither command seems to touch the configuration of the driver chip.

It is not known how frequently sleep() and wake() can be called.

Thank you for creating a pull request to contribute to Adafruit's GitHub code!
Before you open the request please review the following guidelines and tips to
help it be more easily integrated:

- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.

Thank you again for contributing!  We will try to test and integrate the change
as soon as we can, but be aware we have many GitHub repositories to manage and
can't immediately respond to every request.  There is no need to bump or check in
on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated--sometimes the
priorities of Adafruit's GitHub code (education, ease of use) might not match the
priorities of the pull request.  Don't fret, the open source community thrives on
forks and GitHub makes it easy to keep your changes in a forked repo.

After reviewing the guidelines above you can delete this text from the pull request.
