### PR TITLE
commented out unused variables

### DIFF
--- a/Adafruit_SSD1305.cpp
+++ b/Adafruit_SSD1305.cpp
@@ -255,10 +255,10 @@ void Adafruit_SSD1305::display(void) {
   // 32-byte transfer condition below.
   yield();
 
-  uint16_t count = WIDTH * ((HEIGHT + 7) / 8);
+//  uint16_t count = WIDTH * ((HEIGHT + 7) / 8);
   uint8_t *ptr = buffer;
   uint8_t dc_byte = 0x40;
-  uint8_t pages = ((HEIGHT + 7) / 8);
+//  uint8_t pages = ((HEIGHT + 7) / 8);
 
   uint8_t bytes_per_page = WIDTH;
   uint8_t maxbuff = 128;

--- a/Adafruit_SSD1305.cpp
+++ b/Adafruit_SSD1305.cpp
@@ -255,10 +255,10 @@ void Adafruit_SSD1305::display(void) {
   // 32-byte transfer condition below.
   yield();
 
-//  uint16_t count = WIDTH * ((HEIGHT + 7) / 8);
+  // uint16_t count = WIDTH * ((HEIGHT + 7) / 8);
   uint8_t *ptr = buffer;
   uint8_t dc_byte = 0x40;
-//  uint8_t pages = ((HEIGHT + 7) / 8);
+  // uint8_t pages = ((HEIGHT + 7) / 8);
 
   uint8_t bytes_per_page = WIDTH;
   uint8_t maxbuff = 128;


### PR DESCRIPTION
2 unused variables probably used for debugging caused compiler warnings.
Commented out "pages" and "count"